### PR TITLE
A version working on Windows 64-bit PC

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,3 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml

--- a/modmw.py
+++ b/modmw.py
@@ -1,32 +1,12 @@
-#!/bin/python3
-
+import argparse
 import os
 import pathlib
-import sys
 import shutil
+from platform import system
 
-config_file_name = "openmw.cfg"
-config_file_path = os.path.join(pathlib.Path.home(), ".config", "openmw", config_file_name)
 
-if (not os.path.exists(config_file_path)):
-	print("Could not find", config_file_name, "at", config_file_path)
-	exit(1)
-
-def getarg(args: list, index: int, arg_type: type):
-	if (index >= len(args)):
-		print("Missing argument", index)
-		exit(1)
-
-	arg = args[index]
-
-	if (type(arg) != arg_type):
-		print("Argument", index, "must be a", str(arg_type))
-		exit(1)
-
-	return arg
-
-def install_mod(args: list) -> None:
-	mod_data_path = getarg(args, 0, str)
+def install_mod(path, config_path) -> None:
+	mod_data_path = path
 
 	if (not os.path.exists(mod_data_path)):
 		print("Path \"%s\" does not exist" % mod_data_path)
@@ -40,7 +20,7 @@ def install_mod(args: list) -> None:
 				print(mod_data_path, "is already installed!")
 				exit(1)
 
-	with open(config_file_path, "a") as config_file:
+	with open(config_path, "a") as config_file:
 		config_file.write("data=\"%s\"\n" % mod_data_path)
 
 		for file_name in os.listdir(mod_data_path):
@@ -49,13 +29,14 @@ def install_mod(args: list) -> None:
 
 	print(mod_data_path, "installed!")
 
-def uninstall_mod(args: list) -> None:
-	mod_data_path = os.path.abspath(getarg(args, 0, str))
 
-	with open(config_file_path, "r") as config_file:
+def uninstall_mod(path, config_path) -> None:
+	mod_data_path = path
+
+	with open(config_path, "r") as config_file:
 		lines = config_file.readlines()
 
-	with open(config_file_path, "w") as config_file:
+	with open(config_path, "w") as config_file:
 		line_index = 0
 
 		while (line_index < len(lines)):
@@ -72,8 +53,9 @@ def uninstall_mod(args: list) -> None:
 
 				line_index += 1
 
-def list_mods(args: list) -> None:
-	with open(config_file_path, "r") as config_file:
+
+def list_mods(config_path) -> None:
+	with open(config_path, "r") as config_file:
 		mod_iterations = 0
 
 		for line in config_file:
@@ -88,30 +70,67 @@ def list_mods(args: list) -> None:
 
 					mod_iterations += 1
 
-def backup_config(args: list) -> None:
-	backup_path = getarg(args, 0, str)
+
+def backup_config(path, config_path) -> None:
+	backup_path = path
 
 	if (not os.path.exists(backup_path) and not os.path.exists(os.path.split(backup_path)[0])):
 		print("Config file backup path is not valid")
 		exit(1)
 
-	shutil.copy2(config_file_path, backup_path)
+	shutil.copy2(config_path, backup_path)
 
-actions = {
-	"install": install_mod,
-	"uninstall": uninstall_mod,
-	"list": list_mods,
-	"backup": backup_config
-}
 
-if (len(sys.argv) < 2):
-	print("Expected an action")
-	exit(1)
+if __name__ == '__main__':
+	parser = argparse.ArgumentParser()
 
-action_name = sys.argv[1]
+	parser.add_argument("--install", type=str, default=None, action="store", required=False,
+						help="Provide this parameter with the path of a single  mod folder that should be added to the "
+							 "config file")
+	parser.add_argument("--uninstall", type=str, default=None, action="store", required=False,
+						help="Provide this parameter with path of a single mod folder that should be removed from the "
+							 "config file")
+	parser.add_argument("--list", default=None, action="store_true", required=False,
+						help="Commands the script to list the current mod folders from the config file.")
+	parser.add_argument("--backup", type=str, default=None, action="store", required=False,
+						help="Provide this parameter with the path where the backup file should be placed.")
+	parser.add_argument("--configfile", type=str, default=None, action="store", required=False,
+						help="In case the config file is not in the default location, provide this parameter with the "
+							 "path including(!) the openmw.cfg file.")
 
-if (not action_name in actions):
-	print("Unknown action \"%s\". Supported actions:" % action_name, list(actions.keys()))
-	exit(1)
+	p = parser.parse_args()
 
-actions[action_name](sys.argv[2:])
+	if (p.configfile):
+		config_file_path = p.configfile
+
+	else:
+
+		config_file_name = "openmw.cfg"
+		plt = system()
+
+		if (plt == "Windows"):
+			config_file_path = os.path.join(pathlib.Path.home(), "Documents", "my games", "openmw", config_file_name)
+		else:
+			config_file_path = os.path.join(pathlib.Path.home(), ".config", "openmw", config_file_name)
+
+	if not (os.path.exists(config_file_path)):
+		print("Could not find", config_file_name, "at", config_file_path)
+		exit(1)
+
+	if (p.install):
+		install_path = p.install
+		install_mod(install_path, config_file_path)
+
+	elif (p.uninstall):
+		uninstall_path = p.uninstall
+		uninstall_mod(uninstall_path, config_file_path)
+
+	elif (p.list):
+		list_mods(config_file_path)
+
+	elif (p.backup):
+		backup_path = p.backup
+		backup_config(backup_path, config_file_path)
+
+	else:
+		print("No valid parameter provided. You can use -h in order to see the valid possibilities.")


### PR DESCRIPTION
Love the idea of the automation of the config changes! This is something that would push me finally in the direction to stop copying over like an amateur things directly to my main OpenMW DataFiles folder.

This is a version of your code with some edits that I could get to run on my windows machine and has the possibility to set a custom path to the config file, what do you think about it?

Changes:
- Add __main__ section.
- Change the arg parsing to a variant that works on my Windows PC
- Remove the /bin/python3 comment at the start as it was leading to errors on my side
- Check if the OS is a Windows and in that case define the default location of the config file
- Add an argument to define the location of the configfile in case not the default location is used. This was used mainly to test the functions